### PR TITLE
build: fix version declaration

### DIFF
--- a/sql-sourcery/info.rkt
+++ b/sql-sourcery/info.rkt
@@ -5,5 +5,5 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/sql-sourcery.scrbl" ())))
 (define pkg-desc "An ORM for mapping structures in Racket to database entries in a SQL database. All versions 0.1.X are unstable Alpha releases.")
-(define version "0.1.0")
+(define version "0.1")
 (define pkg-authors '(adjkant))


### PR DESCRIPTION
I've recently [changed] `raco setup` to report invalid package versions (according to this [spec]) and I'm slowly going through all published packages that have version issues to fix them in anticipation of that change being released in 8.9.

[changed]: https://github.com/racket/racket/pull/4588
[spec]: https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29